### PR TITLE
fixing dotty compilation of Schedule.scala

### DIFF
--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -291,7 +291,7 @@ trait Schedule[-R, -A, +B] extends Serializable { self =>
       val initial =
         for {
           oldEnv <- ZIO.environment[R1]
-          env    = ev1.update(oldEnv, proxy(_, oldEnv))
+          env    = ev1.update(oldEnv, proxy(_: Clock.Service, oldEnv))
           init   <- self.initial.provide(env)
         } yield (init, env)
       val extract = (a: A, s: State) => self.extract(a, s._1)
@@ -440,7 +440,7 @@ trait Schedule[-R, -A, +B] extends Serializable { self =>
       val initial = self.initial
       val extract = (a: A, s: self.State) => self.extract(a, s)
       val update = (a: A, s: self.State) =>
-        self.update(a, s).provideSome[R1](env => ev1.update(env, proxy(_, env, self.extract(a, s))))
+        self.update(a, s).provideSome[R1](env => ev1.update(env, proxy(_: Clock.Service, env, self.extract(a, s))))
     }
   }
 


### PR DESCRIPTION
Schedule now compiles but there is an `AssertionError` in dottyc in [PlatformSpecific.scala](test/jvm/src/main/scala/zio/test/environment/PlatformSpecific.scala)

```
[error] ## Exception when compiling 61 sources to /Users/dmitryka/dev/com.github/jdegoes/zio/test/jvm/target/scala-0.21/classes
[error] java.lang.AssertionError: Failure to join alternatives zio.Has[zio.test.Annotations.Service] & zio.Has[zio.blocking.Blocking.Service] &
[error]    
[error] (zio.Has[zio.clock.Clock.Service] & (
[error]   zio.Has[zio.test.environment.TestClock.Service]
[error]  & zio.Has[zio.scheduler.Scheduler.Service]))
[error]  & (zio.Has[zio.console.Console.Service] & 
[error]   zio.Has[zio.test.environment.TestConsole.Service]
[error] ) & zio.Has[zio.test.environment.Live.Service] & (
[error]   zio.Has[zio.random.Random.Service]
[error]  & zio.Has[zio.test.environment.TestRandom.Service]) & 
[error]   zio.Has[zio.test.Sized.Service] and zio.Has[zio.system.System.Service] & 
[error]   zio.Has[zio.test.environment.TestSystem.Service]
[error] dotty.tools.dotc.core.TypeOps.fail$1(TypeOps.scala:200)
[error] dotty.tools.dotc.core.TypeOps.mergeRefinedOrApplied$1(TypeOps.scala:223)
[error] dotty.tools.dotc.core.TypeOps.baseTp$2$$anonfun$2(TypeOps.scala:310)
[error] dotty.tools.dotc.core.Types$Type.mapReduceOr(Types.scala:404)
```
Asked about it on [Dotty Gitter](https://gitter.im/lampepfl/dotty)