### PR TITLE
Harden Tests To Potential DateTimeException

### DIFF
--- a/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
@@ -352,8 +352,8 @@ object FiberRefSpec extends ZIOBaseSpec {
 
 object FiberRefSpecUtil {
   val (initial, update, update1, update2) = ("initial", "update", "update1", "update2")
-  val looseTimeAndCpu: ZIO[Live, Nothing, (Long, Long)] = Live.live {
-    ZIO.yieldNow.repeat(Schedule.spaced(Duration.fromNanos(1)) && Schedule.recurs(100))
+  val looseTimeAndCpu: ZIO[Live, Nothing, Unit] = Live.live {
+    (ZIO.yieldNow <* clock.sleep(1.nano)).repeatN(100)
   }
 
   def setRefOrHandle(fiberRef: FiberRef[Int], value: Int): UIO[Unit] =

--- a/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZQueueSpec.scala
@@ -793,7 +793,7 @@ object ZQueueSpec extends ZIOBaseSpec {
 
 object ZQueueSpecUtil {
   def waitForValue[T](ref: UIO[T], value: T): URIO[Live, T] =
-    Live.live((ref <* clock.sleep(10.millis)).repeat(Schedule.doWhile(_ != value)))
+    Live.live((ref <* clock.sleep(10.millis)).repeatUntil(_ == value))
 
   def waitForSize[RA, EA, RB, EB, A, B](queue: ZQueue[RA, EA, RB, EB, A, B], size: Int): URIO[Live, Int] =
     waitForValue(queue.size, size)

--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -7,7 +7,7 @@ import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test.TestUtils._
 import zio.test.environment.TestRandom
-import zio.{ Ref, Schedule, TracingStatus, ZIO }
+import zio.{ Ref, TracingStatus, ZIO }
 
 object TestAspectSpec extends ZIOBaseSpec {
 
@@ -208,15 +208,6 @@ object TestAspectSpec extends ZIOBaseSpec {
         assertM(ZIO.fail("fail"))(anything)
       } @@ nonTermination(1.minute) @@ failing
     ),
-    testM("retry retries failed tests according to a schedule") {
-      for {
-        ref <- Ref.make(0)
-        spec = testM("retry") {
-          assertM(ref.updateAndGet(_ + 1))(equalTo(2))
-        } @@ retry(Schedule.recurs(1))
-        result <- succeeded(spec)
-      } yield assert(result)(isTrue)
-    },
     testM("scala2 applies test aspect only on Scala 2") {
       for {
         ref    <- Ref.make(false)

--- a/test/shared/src/main/scala/zio/test/environment/package.scala
+++ b/test/shared/src/main/scala/zio/test/environment/package.scala
@@ -359,11 +359,10 @@ package object environment extends PlatformSpecific {
        * Polls until all descendants of this fiber are done or suspended.
        */
       private lazy val awaitSuspended: UIO[Unit] =
-        live.provide {
-          suspended.repeat {
-            Schedule.doUntilEquals(true) && Schedule.spaced(5.milliseconds)
-          }
-        }.unit
+        suspended.flatMap { b =>
+          if (b) ZIO.unit
+          else live.provide(awaitSuspended.delay(5.milliseconds))
+        }
 
       /**
        * Delays for a short period of time.


### PR DESCRIPTION
Refactors ZIO Test combinators to avoid unnecessarily using schedule with the live clock so that tests will not be subject to a potential `DateTimeException` on Scala.js.