### PR TITLE
Set Next Runnable

### DIFF
--- a/core/jvm/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm/src/main/scala/zio/internal/ZScheduler.scala
@@ -126,6 +126,7 @@ private final class ZScheduler extends Executor {
         }
         true
       } else {
+        worker.nextRunnable = runnable
         false
       }
     } else {


### PR DESCRIPTION
We potentially took the `runnable` from the `queue` so we need to take responsibility for ensuring this is run. We can do this by setting the `runnable` in the `nextRunnable` slot of the worker. The `nextRunnable` slow is local to the worker so the fiber that calls `stealWork` should suspend immediately after `stealWork` returns `false` so that `nextRunnable` is run by the worker immediately thereafter.