### PR TITLE
Add benchmarks for Optic.Lens

### DIFF
--- a/benchmarks/src/main/scala/zio/blocks/schema/OpticBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/blocks/schema/OpticBenchmark.scala
@@ -30,19 +30,19 @@ class LensGetBenchmark {
   @Benchmark
   def optionPresent: Option[String] = for {
     aOpt <- Option(a)
-    b <- Option(aOpt.b)
-    c <- Option(b.c)
-    d <- Option(c.d)
-    e <- Option(d.e)
+    b    <- Option(aOpt.b)
+    c    <- Option(b.c)
+    d    <- Option(c.d)
+    e    <- Option(d.e)
   } yield e.s
 
   @Benchmark
   def optionAbsent: Option[String] = for {
     aOpt <- Option(aWithNull)
-    b <- Option(aOpt.b)
-    c <- Option(b.c)
-    d <- Option(c.d)
-    e <- Option(d.e)
+    b    <- Option(aOpt.b)
+    c    <- Option(b.c)
+    d    <- Option(c.d)
+    e    <- Option(d.e)
   } yield e.s
 }
 
@@ -207,7 +207,7 @@ object Domain {
       doc = Doc.Empty,
       modifiers = Nil
     )
-    val b: Lens.Bound[A, B] = Lens(reflect, reflect.fields(0).asInstanceOf[Term.Bound[A, B]])
+    val b: Lens.Bound[A, B]              = Lens(reflect, reflect.fields(0).asInstanceOf[Term.Bound[A, B]])
     val b_c_d_e_s: Lens.Bound[A, String] = b.apply(B.c).apply(C.d).apply(D.e).apply(E.s)
   }
 }

--- a/benchmarks/src/main/scala/zio/blocks/schema/OpticBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/blocks/schema/OpticBenchmark.scala
@@ -1,0 +1,213 @@
+package zio.blocks.schema
+
+import org.openjdk.jmh.annotations.{Scope => JScope, _}
+import zio.blocks.schema.binding.RegisterOffset.RegisterOffset
+import zio.blocks.schema.binding.{Binding, Constructor, Deconstructor, RegisterOffset, Registers}
+import java.util.concurrent.TimeUnit
+
+@State(JScope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1)
+class LensGetBenchmark {
+  import Domain._
+
+  var a: A = A(B(C(D(E("test")))))
+
+  var aWithNull: A = A(B(null))
+
+  @Benchmark
+  def unsafePresent: String = a.b.c.d.e.s
+
+  @Benchmark
+  def zioBlocksPresent: String = A.b_c_d_e_s.get(a)
+
+  @Benchmark
+  def zioBlocksAbsent: String = A.b_c_d_e_s.get(aWithNull)
+
+  @Benchmark
+  def optionPresent: Option[String] = for {
+    aOpt <- Option(a)
+    b <- Option(aOpt.b)
+    c <- Option(b.c)
+    d <- Option(c.d)
+    e <- Option(d.e)
+  } yield e.s
+
+  @Benchmark
+  def optionAbsent: Option[String] = for {
+    aOpt <- Option(aWithNull)
+    b <- Option(aOpt.b)
+    c <- Option(b.c)
+    d <- Option(c.d)
+    e <- Option(d.e)
+  } yield e.s
+}
+
+@State(JScope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1)
+class LensSetBenchmark {
+  import Domain._
+
+  var a: A = A(B(C(D(E("test")))))
+
+  var aWithNull: A = A(B(null))
+
+  @Benchmark
+  def unsafePresent: A = a.copy(b = a.b.copy(c = a.b.c.copy(d = a.b.c.d.copy(e = a.b.c.d.e.copy(s = "test2")))))
+
+  @Benchmark
+  def zioBlocksPresent: A = A.b_c_d_e_s.set(a, "test2")
+
+  @Benchmark
+  def zioBlocksAbsent: A = A.b_c_d_e_s.set(aWithNull, "test2")
+}
+
+object Domain {
+  case class E(s: String)
+
+  object E {
+    val reflect: Reflect.Record.Bound[E] = Reflect.Record(
+      fields = List(
+        Term("s", Reflect.string, Doc.Empty, Nil)
+      ),
+      typeName = TypeName(Namespace(List("zio", "blocks", "schema"), Nil), "E"),
+      recordBinding = Binding.Record(
+        constructor = new Constructor[E] {
+          def usedRegisters: RegisterOffset = RegisterOffset(objects = 1)
+
+          def construct(in: Registers, baseOffset: RegisterOffset): E =
+            E(in.getObject(baseOffset, 0).asInstanceOf[String])
+        },
+        deconstructor = new Deconstructor[E] {
+          def usedRegisters: RegisterOffset = RegisterOffset(objects = 1)
+
+          def deconstruct(out: Registers, baseOffset: RegisterOffset, in: E): Unit =
+            out.setObject(baseOffset, 0, in.s)
+        }
+      ),
+      doc = Doc.Empty,
+      modifiers = Nil
+    )
+    val s: Lens.Bound[E, String] = Lens(reflect, reflect.fields(0).asInstanceOf[Term.Bound[E, String]])
+  }
+
+  case class D(e: E)
+
+  object D {
+    val reflect: Reflect.Record.Bound[D] = Reflect.Record(
+      fields = List(
+        Term("e", E.reflect, Doc.Empty, Nil)
+      ),
+      typeName = TypeName(Namespace(List("zio", "blocks", "schema"), Nil), "D"),
+      recordBinding = Binding.Record(
+        constructor = new Constructor[D] {
+          def usedRegisters: RegisterOffset = RegisterOffset(objects = 1)
+
+          def construct(in: Registers, baseOffset: RegisterOffset): D =
+            D(in.getObject(baseOffset, 0).asInstanceOf[E])
+        },
+        deconstructor = new Deconstructor[D] {
+          def usedRegisters: RegisterOffset = RegisterOffset(objects = 1)
+
+          def deconstruct(out: Registers, baseOffset: RegisterOffset, in: D): Unit =
+            out.setObject(baseOffset, 0, in.e)
+        }
+      ),
+      doc = Doc.Empty,
+      modifiers = Nil
+    )
+    val e: Lens.Bound[D, E] = Lens(reflect, reflect.fields(0).asInstanceOf[Term.Bound[D, E]])
+  }
+
+  case class C(d: D)
+
+  object C {
+    val reflect: Reflect.Record.Bound[C] = Reflect.Record(
+      fields = List(
+        Term("d", D.reflect, Doc.Empty, Nil)
+      ),
+      typeName = TypeName(Namespace(List("zio", "blocks", "schema"), Nil), "C"),
+      recordBinding = Binding.Record(
+        constructor = new Constructor[C] {
+          def usedRegisters: RegisterOffset = RegisterOffset(objects = 1)
+
+          def construct(in: Registers, baseOffset: RegisterOffset): C =
+            C(in.getObject(baseOffset, 0).asInstanceOf[D])
+        },
+        deconstructor = new Deconstructor[C] {
+          def usedRegisters: RegisterOffset = RegisterOffset(objects = 1)
+
+          def deconstruct(out: Registers, baseOffset: RegisterOffset, in: C): Unit =
+            out.setObject(baseOffset, 0, in.d)
+        }
+      ),
+      doc = Doc.Empty,
+      modifiers = Nil
+    )
+    val d: Lens.Bound[C, D] = Lens(reflect, reflect.fields(0).asInstanceOf[Term.Bound[C, D]])
+  }
+
+  case class B(c: C)
+
+  object B {
+    val reflect: Reflect.Record.Bound[B] = Reflect.Record(
+      fields = List(
+        Term("c", C.reflect, Doc.Empty, Nil)
+      ),
+      typeName = TypeName(Namespace(List("zio", "blocks", "schema"), Nil), "B"),
+      recordBinding = Binding.Record(
+        constructor = new Constructor[B] {
+          def usedRegisters: RegisterOffset = RegisterOffset(objects = 1)
+
+          def construct(in: Registers, baseOffset: RegisterOffset): B =
+            B(in.getObject(baseOffset, 0).asInstanceOf[C])
+        },
+        deconstructor = new Deconstructor[B] {
+          def usedRegisters: RegisterOffset = RegisterOffset(objects = 1)
+
+          def deconstruct(out: Registers, baseOffset: RegisterOffset, in: B): Unit =
+            out.setObject(baseOffset, 0, in.c)
+        }
+      ),
+      doc = Doc.Empty,
+      modifiers = Nil
+    )
+    val c: Lens.Bound[B, C] = Lens(reflect, reflect.fields(0).asInstanceOf[Term.Bound[B, C]])
+  }
+
+  case class A(b: B)
+
+  object A {
+    val reflect: Reflect.Record.Bound[A] = Reflect.Record(
+      fields = List(
+        Term("b", B.reflect, Doc.Empty, Nil)
+      ),
+      typeName = TypeName(Namespace(List("zio", "blocks", "schema"), Nil), "A"),
+      recordBinding = Binding.Record(
+        constructor = new Constructor[A] {
+          def usedRegisters: RegisterOffset = RegisterOffset(objects = 1)
+
+          def construct(in: Registers, baseOffset: RegisterOffset): A =
+            A(in.getObject(baseOffset, 0).asInstanceOf[B])
+        },
+        deconstructor = new Deconstructor[A] {
+          def usedRegisters: RegisterOffset = RegisterOffset(objects = 1)
+
+          def deconstruct(out: Registers, baseOffset: RegisterOffset, in: A): Unit =
+            out.setObject(baseOffset, 0, in.b)
+        }
+      ),
+      doc = Doc.Empty,
+      modifiers = Nil
+    )
+    val b: Lens.Bound[A, B] = Lens(reflect, reflect.fields(0).asInstanceOf[Term.Bound[A, B]])
+    val b_c_d_e_s: Lens.Bound[A, String] = b.apply(B.c).apply(C.d).apply(D.e).apply(E.s)
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -670,7 +670,7 @@ lazy val examples = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .nativeSettings(nativeSettings)
 
 lazy val benchmarks = project.module
-  .dependsOn(core.jvm, streams.jvm, tests.jvm)
+  .dependsOn(core.jvm, streams.jvm, tests.jvm, zioBlocks.jvm)
   .enablePlugins(JmhPlugin)
   .settings(replSettings)
   .settings(


### PR DESCRIPTION
Below are results with Scala 3 and JDK 21 on Intel® Core™ i7-11800H:
```
[info] Benchmark                           Mode  Cnt          Score         Error  Units
[info] LensGetBenchmark.optionAbsent      thrpt    5  249263334.780 ± 5011764.707  ops/s
[info] LensGetBenchmark.optionPresent     thrpt    5  146478192.473 ± 6401942.599  ops/s
[info] LensGetBenchmark.unsafePresent     thrpt    5  949678724.187 ± 5104999.528  ops/s
[info] LensGetBenchmark.zioBlocksPresent  thrpt    5    6086198.757 ±  842825.156  ops/s
[info] LensSetBenchmark.unsafePresent     thrpt    5  147641675.361 ± 3330442.403  ops/s
[info] LensSetBenchmark.zioBlocksPresent  thrpt    5    1843076.253 ±   33022.323  ops/s
```