### PR TITLE
Unsafe optic 1

### DIFF
--- a/benchmarks/src/main/scala/zio/blocks/schema/OpticBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/blocks/schema/OpticBenchmark.scala
@@ -16,33 +16,30 @@ class LensGetBenchmark {
 
   var a: A = A(B(C(D(E("test")))))
 
-  var aWithNull: A = A(B(null))
+  var aWithCNull: A = A(B(null))
 
   @Benchmark
-  def unsafePresent: String = a.b.c.d.e.s
+  def directPresent: String = a.b.c.d.e.s
 
   @Benchmark
   def zioBlocksPresent: String = A.b_c_d_e_s.get(a)
 
   @Benchmark
-  def zioBlocksAbsent: String = A.b_c_d_e_s.get(aWithNull)
-
-  @Benchmark
   def optionPresent: Option[String] = for {
-    aOpt <- Option(a)
-    b    <- Option(aOpt.b)
-    c    <- Option(b.c)
-    d    <- Option(c.d)
-    e    <- Option(d.e)
+    a <- Option(this.a)
+    b <- Option(a.b)
+    c <- Option(b.c)
+    d <- Option(c.d)
+    e <- Option(d.e)
   } yield e.s
 
   @Benchmark
   def optionAbsent: Option[String] = for {
-    aOpt <- Option(aWithNull)
-    b    <- Option(aOpt.b)
-    c    <- Option(b.c)
-    d    <- Option(c.d)
-    e    <- Option(d.e)
+    a <- Option(aWithCNull)
+    b <- Option(a.b)
+    c <- Option(b.c)
+    d <- Option(c.d)
+    e <- Option(d.e)
   } yield e.s
 }
 
@@ -57,16 +54,16 @@ class LensSetBenchmark {
 
   var a: A = A(B(C(D(E("test")))))
 
-  var aWithNull: A = A(B(null))
+  var aWithCNull: A = A(B(null))
 
   @Benchmark
-  def unsafePresent: A = a.copy(b = a.b.copy(c = a.b.c.copy(d = a.b.c.d.copy(e = a.b.c.d.e.copy(s = "test2")))))
+  def directPresent: A = a.copy(b = a.b.copy(c = a.b.c.copy(d = a.b.c.d.copy(e = a.b.c.d.e.copy(s = "test2")))))
 
   @Benchmark
   def zioBlocksPresent: A = A.b_c_d_e_s.set(a, "test2")
 
   @Benchmark
-  def zioBlocksAbsent: A = A.b_c_d_e_s.set(aWithNull, "test2")
+  def zioBlocksAbsent: A = A.b_c_d_e_s.set(aWithCNull, "test2")
 }
 
 object Domain {

--- a/zio-blocks/src/main/scala/zio/blocks/schema/Optic.scala
+++ b/zio-blocks/src/main/scala/zio/blocks/schema/Optic.scala
@@ -109,9 +109,70 @@ sealed trait Lens[F[_, _], S, A] extends Optic[F, S, A] {
 object Lens {
   type Bound[S, A] = Lens[Binding, S, A]
 
-  def apply[F[_, _], S, A](parent: Reflect.Record[F, S], child: Term[F, S, A]): Lens[F, S, A] = new Field(parent, child)
+  def apply[F[_, _], S, A](parent: Reflect.Record[F, S], child: Term[F, S, A]): Lens[F, S, A] =
+    new UnsafeOptic(ArraySeq(parent), ArraySeq(child))
 
-  def apply[F[_, _], S, T, A](first: Lens[F, S, T], second: Lens[F, T, A]): Lens[F, S, A] = new LensLens(first, second)
+  def apply[F[_, _], S, T, A](first: Lens[F, S, T], second: Lens[F, T, A]): Lens[F, S, A] = {
+    val u1 = first.asInstanceOf[UnsafeOptic[F, S, A]]
+    val u2 = second.asInstanceOf[UnsafeOptic[F, S, A]]
+    new UnsafeOptic(u1.parents ++ u2.parents, u1.childs ++ u2.childs)
+  }
+
+  private case class UnsafeOptic[F[_, _], S, A](
+    parents: ArraySeq[Reflect.Record[F, S]],
+    childs: ArraySeq[Term[F, S, A]]
+  ) extends Lens[F, S, A]
+      with Leaf[F, S, A] {
+    private[this] val regs: Array[Register[_]] = {
+      val len = parents.length
+      val rs  = new Array[Register[_]](len)
+      var i   = 0
+      while (i < len) {
+        rs(i) = parents(i).registers(parents(i).fields.indexWhere(_.name == childs(i).name))
+        i += 1
+      }
+      rs
+    }
+    private[this] val offs = regs.map {
+      var offset = RegisterOffset.Zero
+      r =>
+        val prevOffset = offset
+        offset = RegisterOffset.add(offset, r.usedRegisters)
+        prevOffset
+    }
+
+    override def get(s: S)(implicit F: HasBinding[F]): A = {
+      val registers = Lens.registers.get // Registers()
+      var x: Any    = s
+      val len       = parents.length
+      var i         = 0
+      while (i < len) {
+        val offset = offs(i)
+        F.deconstructor(parents(i).recordBinding).deconstruct(registers, offset, x.asInstanceOf[S])
+        x = regs(i).get(registers, offset)
+        i += 1
+      }
+      x.asInstanceOf[A]
+    }
+
+    override def set(s: S, a: A)(implicit F: HasBinding[F]): S = ???
+
+    override def refineBinding[G[_, _]](f: RefineBinding[F, G]): Lens[G, S, A] = ???
+    // new UnsafeOptic(parents.map(_.refineBinding(f)), childs.map(_.refineBinding(f)))
+
+    override def structure: Reflect[F, S] = parents(0)
+
+    override def focus: Reflect[F, A] = childs(childs.length - 1).value
+
+    override def hashCode: Int = parents.hashCode ^ childs.hashCode
+
+    override def equals(obj: Any): Boolean = obj match {
+      case other: UnsafeOptic[F, _, _] => other.parents.equals(parents) && other.childs.equals(childs)
+      case _                           => false
+    }
+
+    override private[schema] def linearized: ArraySeq[Leaf[F, S, A]] = ???
+  }
 
   private case class Field[F[_, _], S, A](parent: Reflect.Record[F, S], child: Term[F, S, A])
       extends Lens[F, S, A]
@@ -167,6 +228,8 @@ object Lens {
 
     private[schema] lazy val linearized: ArraySeq[Leaf[F, _, _]] = first.linearized ++ second.linearized
   }
+
+  private val registers = ThreadLocal.withInitial(() => Registers())
 }
 
 sealed trait Prism[F[_, _], S, A] extends Optic[F, S, A] {


### PR DESCRIPTION
DO NOT MERGE

This PR just a try to get maximum performance for `LensLens.get` by using `UnsafeOptic` with a thread local value for `Registers` to avoid allocations.

Here are results with Scala 3 and JDK 21 on Intel® Core™ i7-11800H:
```
[info] Benchmark                           Mode  Cnt          Score          Error  Units
[info] LensGetBenchmark.directPresent     thrpt    5  951050089.828 ± 10923136.957  ops/s
[info] LensGetBenchmark.optionAbsent      thrpt    5  253388087.375 ± 49053410.046  ops/s
[info] LensGetBenchmark.optionPresent     thrpt    5  149130636.482 ±  5145067.782  ops/s
[info] LensGetBenchmark.zioBlocksPresent  thrpt    5   27720600.487 ±   254679.135  ops/s
```

The flame graph from async-profiler shows that most CPU cycles are burned in non-inlined `deconstruct` virtual method calls:

![image](https://github.com/user-attachments/assets/d056cbec-1a26-4cc1-a2ed-83624b0fd70f)

  

