### PR TITLE
Add benchmarks for Monocle and Quicklens

### DIFF
--- a/benchmarks/src/main/scala/zio/blocks/schema/OpticBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/blocks/schema/OpticBenchmark.scala
@@ -16,34 +16,14 @@ class LensGetBenchmark {
 
   var a: A = A(B(C(D(E("test")))))
 
-  var aWithNull: A = A(B(null))
+  @Benchmark
+  def direct: String = a.b.c.d.e.s
 
   @Benchmark
-  def unsafePresent: String = a.b.c.d.e.s
+  def monocle: String = A.b_c_d_e_s_monocle_get.get(a)
 
   @Benchmark
-  def zioBlocksPresent: String = A.b_c_d_e_s.get(a)
-
-  @Benchmark
-  def zioBlocksAbsent: String = A.b_c_d_e_s.get(aWithNull)
-
-  @Benchmark
-  def optionPresent: Option[String] = for {
-    aOpt <- Option(a)
-    b    <- Option(aOpt.b)
-    c    <- Option(b.c)
-    d    <- Option(c.d)
-    e    <- Option(d.e)
-  } yield e.s
-
-  @Benchmark
-  def optionAbsent: Option[String] = for {
-    aOpt <- Option(aWithNull)
-    b    <- Option(aOpt.b)
-    c    <- Option(b.c)
-    d    <- Option(c.d)
-    e    <- Option(d.e)
-  } yield e.s
+  def zioBlocks: String = A.b_c_d_e_s.get(a)
 }
 
 @State(JScope.Thread)
@@ -57,16 +37,17 @@ class LensSetBenchmark {
 
   var a: A = A(B(C(D(E("test")))))
 
-  var aWithNull: A = A(B(null))
+  @Benchmark
+  def direct: A = a.copy(b = a.b.copy(c = a.b.c.copy(d = a.b.c.d.copy(e = a.b.c.d.e.copy(s = "test2")))))
 
   @Benchmark
-  def unsafePresent: A = a.copy(b = a.b.copy(c = a.b.c.copy(d = a.b.c.d.copy(e = a.b.c.d.e.copy(s = "test2")))))
+  def monocle: A = A.b_c_d_e_s_monocle_set.replace("test2").apply(a)
 
   @Benchmark
-  def zioBlocksPresent: A = A.b_c_d_e_s.set(a, "test2")
+  def quicklens: A = A.b_c_d_e_s_qiocklens.apply(a).setTo("test2")
 
   @Benchmark
-  def zioBlocksAbsent: A = A.b_c_d_e_s.set(aWithNull, "test2")
+  def zioBlocks: A = A.b_c_d_e_s.set(a, "test2")
 }
 
 object Domain {
@@ -209,5 +190,22 @@ object Domain {
     )
     val b: Lens.Bound[A, B]              = Lens(reflect, reflect.fields(0).asInstanceOf[Term.Bound[A, B]])
     val b_c_d_e_s: Lens.Bound[A, String] = b.apply(B.c).apply(C.d).apply(D.e).apply(E.s)
+
+    import com.softwaremill.quicklens._
+
+    val b_c_d_e_s_qiocklens =
+      (modify(_: A)(_.b))
+        .andThenModify(modify(_: B)(_.c))
+        .andThenModify(modify(_: C)(_.d))
+        .andThenModify(modify(_: D)(_.e))
+        .andThenModify(modify(_: E)(_.s))
+
+    import monocle.Focus
+
+    val b_c_d_e_s_monocle_get =
+      Focus[A](_.b).andThen(Focus[B](_.c)).andThen(Focus[C](_.d)).andThen(Focus[D](_.e)).andThen(Focus[E](_.s)).asGetter
+
+    val b_c_d_e_s_monocle_set =
+      Focus[A](_.b).andThen(Focus[B](_.c)).andThen(Focus[C](_.d)).andThen(Focus[D](_.e)).andThen(Focus[E](_.s)).asSetter
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -678,18 +678,21 @@ lazy val benchmarks = project.module
     libraryDependencies ++= {
       val nyanaVersion = if (scalaVersion.value == Scala212) "0.10.0" else "1.1.0"
       Seq(
-        "co.fs2"                    %% "fs2-core"      % Fs2Version,
-        "com.twitter"               %% "util-core"     % "24.2.0",
-        "com.typesafe.akka"         %% "akka-stream"   % "2.8.8",
-        "io.github.timwspence"      %% "cats-stm"      % "0.13.4",
-        "io.projectreactor"          % "reactor-core"  % "3.7.0",
-        "io.reactivex.rxjava2"       % "rxjava"        % "2.2.21",
-        "org.jctools"                % "jctools-core"  % "4.0.5",
-        "org.typelevel"             %% "cats-effect"   % CatsEffectVersion,
-        "org.scalacheck"            %% "scalacheck"    % ScalaCheckVersion,
-        "qa.hedgehog"               %% "hedgehog-core" % "0.11.0",
-        "com.github.japgolly.nyaya" %% "nyaya-gen"     % nyanaVersion,
-        "org.springframework"        % "spring-core"   % "6.2.0"
+        "co.fs2"                     %% "fs2-core"      % Fs2Version,
+        "com.twitter"                %% "util-core"     % "24.2.0",
+        "com.typesafe.akka"          %% "akka-stream"   % "2.8.8",
+        "io.github.timwspence"       %% "cats-stm"      % "0.13.4",
+        "io.projectreactor"           % "reactor-core"  % "3.7.0",
+        "io.reactivex.rxjava2"        % "rxjava"        % "2.2.21",
+        "org.jctools"                 % "jctools-core"  % "4.0.5",
+        "org.typelevel"              %% "cats-effect"   % CatsEffectVersion,
+        "org.scalacheck"             %% "scalacheck"    % ScalaCheckVersion,
+        "qa.hedgehog"                %% "hedgehog-core" % "0.11.0",
+        "com.github.japgolly.nyaya"  %% "nyaya-gen"     % nyanaVersion,
+        "org.springframework"         % "spring-core"   % "6.2.0",
+        "com.softwaremill.quicklens" %% "quicklens"     % "1.9.12",
+        "dev.optics"                 %% "monocle-core"  % "3.1.0",
+        "dev.optics"                 %% "monocle-macro" % "3.1.0"
       )
     },
     excludeDependencies ++= {


### PR DESCRIPTION
Below are results with Scala 3 and JDK 21 on Intel® Core™ i7-11800H:
```
[info] Benchmark                    Mode  Cnt          Score         Error  Units
[info] LensGetBenchmark.direct     thrpt    5  950164030.322 ± 4591286.898  ops/s
[info] LensGetBenchmark.monocle    thrpt    5   69602489.161 ± 1352954.843  ops/s
[info] LensGetBenchmark.zioBlocks  thrpt    5    5924841.874 ±   64262.497  ops/s
[info] LensSetBenchmark.direct     thrpt    5  145927220.160 ± 9875733.257  ops/s
[info] LensSetBenchmark.monocle    thrpt    5   49551311.383 ±  334573.830  ops/s
[info] LensSetBenchmark.quicklens  thrpt    5   19328610.583 ± 1524121.740  ops/s
[info] LensSetBenchmark.zioBlocks  thrpt    5    6285942.456 ±  118330.468  ops/s
```